### PR TITLE
Fix rounding bug

### DIFF
--- a/TwoOpt.cpp
+++ b/TwoOpt.cpp
@@ -60,13 +60,7 @@ int City::getDist(City otherCity) {
     double ydist = getYCoord() - otherCity.getYCoord();
     double result= sqrt(pow(xdist, 2.0) + pow(ydist, 2.0));
     double temp = round(result);
-
-    if(temp - result < 0)
-    {
-    	return (int) temp +1;
-    }
-    else return (int) temp;
-
+    return (int)temp;
 }
 
 DistanceMatrix::DistanceMatrix(std::vector<City>* cities) {


### PR DESCRIPTION
Round function already rounds a number to the nearest integer (it doesn't take the floor), so I removed the section that would check to see if temp < result. This was resulting in the python tsp-verifier.py giving a different tour length than our answer.